### PR TITLE
Slurm job example on the VIB Data Core Compute Cluster

### DIFF
--- a/code/example_slurm/slurm_vib.sh
+++ b/code/example_slurm/slurm_vib.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
-#SBATCH --ntasks=1
-#SBATCH --partition=gpu_a100_48C_96T_512GB
+#SBATCH --job-name=test_job_submission
+#SBATCH --partition=debug_28C_56T_750GB
+#SBATCH --mem=8G
 #SBATCH --time=00:30:00
-#SBATCH --job-name=denoising_training
-#SBATCH --output=denoising_training.out
-#SBATCH --error=denoising.err
-#SBATCH --cpus-per-task=16
-#SBATCH --gres=gpu:1
-#SBATCH --mem=32G
 
+# Define variables
+DOCKER_IMG="docker://hello-world"
+
+# Practice best practice by purging all loaded modules first
 module purge
-module load n2v/0.3.2-foss-2022a-CUDA-11.7.0
 
-python  /data/projects/s20/twoller/Anneke_EM/00_01_training_denoising_batch.py 
+# Load necessary modules (none needed for this example)
+# module load Python/3.13.1-GCCcore-14.2.0
+
+# Pull minimal Docker image using Singularity
+singularity pull $DOCKER_IMG
+
+# Sleep for 20 seconds so there is time to see the job via `squeue`
+echo 'Going to sleep for 20 seconds... ZZZzzzzz....'
+sleep 20


### PR DESCRIPTION
On debug node, minimal container pull that ties into container training, sleep command so users have time to see job in `squeue`, best practices, minimal Slurm directives to not overwhelm new users. 